### PR TITLE
Retry after consumer failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 test:
-	py.test
+	py.test -v -s
 
 coverage:
 	coverage run --source domain_events -m py.test && coverage report -m --omit=domain_events/_version.py

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Domain events
-=============
+# Domain events
 
 This library provides a shallow layer on top of [RabbitMQ topic
 exchanges](https://www.rabbitmq.com/tutorials/tutorial-five-python.html) for
@@ -8,8 +7,7 @@ each other and can be started and stopped in any order. Each receiver controls
 their own retry policy, whether they need a durable queue for the time they are
 down, or a dead-letter queue in case there is an error in the receiver.
 
-Configuration
--------------
+## Configuration
 
 This library needs to connect to RabbitMQ. By default, a local instance of
 RabbitMQ is used. This can be changed by calling configure with an [amqp
@@ -18,8 +16,7 @@ URL](http://pika.readthedocs.org/en/latest/examples/using_urlparameters.html):
     from domain_events import configure
     configure('amqp://user:password@rabbitmq-host/domain-events')
 
-Sending events
---------------
+## Sending events
 
 Events can be sent by calling `emit_domain_event`:
 
@@ -34,8 +31,7 @@ clear emitted events without sending, `discard` can be used. When using
 database transactions, these functions should be called in a middleware or in a
 post-transaction hook.
 
-Receiving events
-----------------
+## Receiving events
 
 Receivers can listen to one or more domain events - controlled via the binding
 keys. Binding keys may contain wildcards. A queue will be created for each
@@ -44,31 +40,59 @@ queue.
 
 This script will receive all events that are sent in the user domain:
 
-    from domain_events import receive_domain_events
+    from domain_events import Receiver
 
     def handle_user_event(event):
         print event
 
-    receive_domain_events(handle_user_event, 'printer', ['user.*'])
+    receiver = Receiver()
+    receiver.register(handle_user_event, 'printer', ['user.*'])
+    receiver.start_consuming()
 
-Development
------------
+### Retry policy
+
+If there is a problem consuming a message - for example a web service is down -
+the receiver can raise an error to retry handling the event after the given delay:
+
+    from domain_events import Receiver
+
+    def sync_user_data(event):
+        try:
+            send_to_service(event)
+        except ServiceIsDown:
+            raise Retry(5.0 ** event.retries) # 1s, 5s, 25s
+
+    receiver = Receiver()
+    receiver.register(sync_user_data, 'sync_data', ['user.*'], max_retries=3)
+    receiver.start_consuming()
+
+The delayed retries are bound to the consumer, not the event. If `max_retries`
+is exceeded, the event will be dropped or dead-lettered.
+
+#### Caveats
+
+The retry policy is implemented using a wait queue with per-message expiry.
+Expired messages will only be re-routed to the receiver when the first message
+in the waiting queue expires. For the example above, if event A has been
+retried for the third time and another event B is retried for the first time,
+both events will only be redelivered after event A expires (25s) even though
+event A is supposed to expire after 1s.
+
+## Development
 
 Make sure you have RabbitMQ installed locally for testing.
 
 * create virtualenv and activate it
 * run `pip install -r requirements.txt -r dev_requirements.txt -e .`
-* the only external dependency (so far) is `pika>=0.9.13`
+* the only external dependency (so far) is `pika`
 
-Architecture
-------------
+## Architecture
 
 There's
 
-* The transport, currently done via rabbitmq: `domain_events.transport`. This should be usable independent of the events.
 * Generic domain events: `domain_events.events`
+* The transport, via rabbitmq: `domain_events.transport`
 
-Testing
--------
+## Testing
 
-Testing is currently done by `py.test` which allows some quite advanced testing features.
+Testing is done by `py.test` which allows some quite advanced testing features.

--- a/domain_events/__init__.py
+++ b/domain_events/__init__.py
@@ -7,13 +7,14 @@ del get_versions
 from transport import (
     configure,
     discard,
+    emit_domain_event,
     transmit,
     DEFAULT_CONNECTION_SETTINGS,
-    Transport,
+    Receiver,
+    Retry,
+    Sender,
 )
 
 from events import (
     DomainEvent,
-    emit_domain_event,
-    receive_domain_events,
 )

--- a/domain_events/events.py
+++ b/domain_events/events.py
@@ -2,14 +2,7 @@ from datetime import datetime
 import json
 from uuid import uuid4
 
-import transport
-
-
 FACTOR = 10**6
-
-
-def get_domain_events_sender(connection_settings):
-    pass
 
 
 def to_timestamp(dt, epoch=datetime(1970,1,1)):
@@ -26,6 +19,7 @@ class DomainEvent(object):
                  domain_object_id=None,
                  uuid_string=None, # only set if recreated from json repr
                  timestamp=None, # only set if recreated from json repr
+                 retries=0,
                  **kwargs):
         """Define a Domain Event
         @routing_key -> str : The routing key is of the form <DOMAIN>.<EVENT_TYPE>
@@ -38,6 +32,8 @@ class DomainEvent(object):
             NOTE: a uuid object can not be serialized in json.
         @timestamp -> float : unix timestamp. If timestamp is None, a new (utc) timestamp will be created.
             NOTE: a datetime object can not be serialized in json.
+
+        @retries -> int : Number of times this event was delivered to a consumer already.
 
         ASSUMPTION: when sending and receiving an event,
         we have a one to one correspondence between event type and queue.
@@ -57,6 +53,7 @@ class DomainEvent(object):
             self.timestamp = timestamp
         event_data = self.__dict__.copy()
         self.event_data = event_data
+        self.retries = retries
 
     @classmethod
     def from_json(cls, json_data):
@@ -66,59 +63,9 @@ class DomainEvent(object):
         return cls(**json.loads(json_data))
 
     def __repr__(self):
-        return u"DomainEvent('{}', '{}', (domain_obj_id: {}))".format(
-            self.routing_key,
-            self.data,
-            self.domain_object_id,
-        )
+        return u"DomainEvent('{0.routing_key}', '{0.data}', (domain_obj_id: {0.domain_object_id}, uuid: {0.uuid_string}))".format(self)
 
     __str__ = __repr__
 
     def __eq__(self, other):
         return self.event_data == other.event_data
-
-
-def emit_domain_event(*args, **kwargs):
-    event = DomainEvent(*args, **kwargs)
-    data = json.dumps(event.event_data)
-    transport.get_transport().push(data, event.routing_key)
-    return event
-
-
-def receive_domain_events(handler, name, binding_keys, dead_letter=False,
-                          durable=True, exclusive=False, auto_delete=False):
-    """
-    Set up a receiver queue and call the given handler for every domain event
-    that is received. The keyword arguments are passed into `Transport.receive`.
-
-    Calling this function will enter an IO loop.
-
-    @handler -> func(event)
-
-    Example:
-
-    >>> receive_domain_events(send_email, name='my-queue', binding_keys=['user.created'])
-
-    Any error raised in the receiver function will remove the event from the
-    queue and put it in the dead-letter queue if there is one.
-    """
-
-    def receive_callback(ch, method, properties, body):
-        event = DomainEvent.from_json(body)
-        print "{}:{}".format(method.routing_key, event)
-        try:
-            handler(event)
-        except:
-            # Note: If we want immediate requeueing, add a `RequeueError` that
-            # a consumer can raise to trigger requeuing. Dead-letter queues are
-            # a better choice in most cases.
-            ch.basic_reject(delivery_tag=method.delivery_tag, requeue=False)
-            raise
-        else:
-            ch.basic_ack(delivery_tag=method.delivery_tag)
-
-    receiver = transport.Transport()
-    receiver.connect()
-    receiver.receive(receive_callback, name, binding_keys=binding_keys,
-                     dead_letter=dead_letter, durable=durable,
-                     exclusive=exclusive, auto_delete=auto_delete)

--- a/domain_events/tests/helpers.py
+++ b/domain_events/tests/helpers.py
@@ -1,0 +1,36 @@
+import pika
+from domain_events import DomainEvent
+
+
+def get_queue_size(name, **kwargs):
+    connection = pika.BlockingConnection()
+    channel = connection.channel()
+    q = channel.queue_declare(name, passive=True, **kwargs)
+    count = q.method.message_count
+    connection.close()
+    return count
+
+
+def check_queue_exists(name, **kwargs):
+    connection = pika.BlockingConnection()
+    channel = connection.channel()
+    try:
+        channel.queue_declare(name, passive=True, **kwargs)
+    except pika.exceptions.ChannelClosed as error:
+        connection.close()
+        return error.args[0] != 404
+    else:
+        connection.close()
+        return True
+
+
+def get_message_from_queue(name, **kwargs):
+    connection = pika.BlockingConnection()
+    channel = connection.channel()
+    method_frame, header, body = channel.basic_get(name)
+    if method_frame:
+        channel.basic_ack(method_frame.delivery_tag)
+        event = DomainEvent.from_json(body)
+        return header, event
+    else:
+        return None, None

--- a/domain_events/tests/test_events.py
+++ b/domain_events/tests/test_events.py
@@ -7,7 +7,7 @@ from domain_events import (
     DomainEvent,
     )
 
-from domain_events.transport import get_transport
+from domain_events.transport import get_sender
 
 
 class TestEvent(object):
@@ -16,7 +16,7 @@ class TestEvent(object):
         """Use basic API to fire event"""
         event = emit_domain_event('test.test', {})
         transmit()
-        json_data, routing_key = get_transport().messages[-1]
+        json_data, routing_key = get_sender().messages[-1]
         event_data = json.loads(json_data)
         assert routing_key == "test.test"
         assert event_data['data'] == {}
@@ -25,21 +25,21 @@ class TestEvent(object):
     def test_event_loading(self):
         event = emit_domain_event('test.test', {})
         transmit()
-        json_data, routing_key = get_transport().messages[-1]
+        json_data, routing_key = get_sender().messages[-1]
 
         new_event = DomainEvent.from_json(json_data)
         assert new_event == event
 
     def test_pending_until_transmitted(self):
         emit_domain_event('test.test', {})
-        assert get_transport().pending
+        assert get_sender().pending
         transmit()
-        assert not get_transport().pending
-        assert get_transport().messages
+        assert not get_sender().pending
+        assert get_sender().messages
 
     def test_pending_until_discarded(self):
         emit_domain_event('test.test', {})
-        assert get_transport().pending
+        assert get_sender().pending
         discard()
-        assert not get_transport().pending
-        assert not get_transport().messages
+        assert not get_sender().pending
+        assert not get_sender().messages

--- a/domain_events/tests/test_queues.py
+++ b/domain_events/tests/test_queues.py
@@ -1,11 +1,5 @@
-from domain_events.transport import Transport
-
-
-def get_transport():
-    transport = Transport(exchange='test_exchange')
-    return transport
+from domain_events.transport import Sender
 
 
 def test_send():
-    transport = get_transport()
-    transport.send('test message', 'x.y')
+    Sender(exchange='test_exchange').send('test message', 'x.y')

--- a/domain_events/tests/test_receiver.py
+++ b/domain_events/tests/test_receiver.py
@@ -1,0 +1,83 @@
+from domain_events import emit_domain_event, Receiver, Retry, transmit
+from .helpers import check_queue_exists, get_message_from_queue, get_queue_size
+import pytest
+import uuid
+
+
+def nop(event):
+    pass
+
+
+class ConsumerError(Exception):
+    pass
+
+
+def raise_error(event):
+    raise ConsumerError("Unexpected error")
+
+
+def test_retry():
+    def raise_retry(event):
+        raise_retry.received += 1
+        raise Retry(0.1)
+    raise_retry.received = 0
+
+    name = 'test-retry'
+    receiver = Receiver()
+    receiver.register(raise_retry, name, ['test.retry'], max_retries=3)
+    data = dict(message=str(uuid.uuid4())[:4])
+    emit_domain_event('test.retry', data)
+    transmit()
+    receiver.start_consuming(timeout=1.0)
+    assert raise_retry.received == 4
+    assert get_queue_size(name) == 0
+
+
+def test_auto_delete():
+    name = 'test-auto-delete'
+    receiver = Receiver()
+    receiver.register(nop, name, ['test.auto_delete'], auto_delete=True)
+    emit_domain_event('test.auto_delete', {})
+    transmit()
+    receiver.start_consuming(timeout=1.0)
+    assert not check_queue_exists(name)
+
+
+def test_multiple_listeneres():
+    def one(event):
+        one.received += 1
+    one.received = 0
+
+    def two(event):
+        two.received += 1
+    two.received = 0
+
+    receiver = Receiver()
+    receiver.register(one, 'test-listener-one', ['test.one'])
+    receiver.register(two, 'test-listener-two', ['test.two'])
+    emit_domain_event('test.one', {})
+    emit_domain_event('test.two', {})
+    transmit()
+    receiver.start_consuming(timeout=1.0)
+    assert one.received == 1
+    assert two.received == 1
+
+
+def test_consumer_timeout():
+    name = 'test-consumer-timeout'
+    receiver = Receiver()
+    receiver.register(nop, name, ['#'])
+    receiver.start_consuming(timeout=1.0)
+
+
+def test_dead_letter():
+    name = 'test-dead-letter'
+    receiver = Receiver()
+    receiver.register(raise_error, name, ['test.dl'], dead_letter=True)
+    data = dict(message=str(uuid.uuid4())[:4])
+    emit_domain_event('test.dl', data)
+    transmit()
+    with pytest.raises(ConsumerError):
+        receiver.start_consuming(timeout=1.0)
+    header, event = get_message_from_queue('test-dead-letter-dl')
+    assert event.data == data

--- a/domain_events/transport.py
+++ b/domain_events/transport.py
@@ -1,9 +1,12 @@
+from functools import partial
 import logging
+import json
 from pika import (
     BasicProperties,
     BlockingConnection,
     URLParameters,
     )
+from .events import DomainEvent
 
 log = logging.getLogger(__name__)
 
@@ -11,7 +14,7 @@ log = logging.getLogger(__name__)
 DEFAULT_CONNECTION_SETTINGS = 'amqp://guest:guest@localhost:5672/%2F'
 
 _connection_settings = DEFAULT_CONNECTION_SETTINGS
-_transport = None
+_sender = None
 
 
 def configure(connection_settings):
@@ -23,21 +26,73 @@ def configure(connection_settings):
     _connection_settings = connection_settings
 
 
-def get_transport():
-    global _transport
-    if _transport is None:
-        _transport = Transport()
-    return _transport
+def get_sender():
+    global _sender
+    if _sender is None:
+        _sender = Sender()
+    return _sender
+
+
+def emit_domain_event(*args, **kwargs):
+    event = DomainEvent(*args, **kwargs)
+    data = json.dumps(event.event_data)
+    get_sender().push(data, event.routing_key)
+    return event
 
 
 def transmit():
-    if _transport is not None:
-        _transport.transmit()
+    if _sender is not None:
+        _sender.transmit()
 
 
 def discard():
-    if _transport is not None:
-        _transport.discard()
+    if _sender is not None:
+        _sender.discard()
+
+
+class Retry(Exception):
+    def __init__(self, delay=10.0):
+        super(Retry, self).__init__()
+        self.delay = delay
+
+
+def receive_callback(handler, delay_exchange, max_retries, channel, method, properties, body):
+    event = DomainEvent.from_json(body)
+    if properties.headers and 'x-death' in properties.headers:
+        # Older RabbitMQ versions (< 3.5) keep adding x-death entries, new
+        # versions only keep the most recent entry and increment 'count', see:
+        # https://github.com/rabbitmq/rabbitmq-server/issues/78
+        expiry_info = properties.headers['x-death'][0]
+        if 'count' in expiry_info:
+            event.retries = expiry_info['count']
+        else:
+            event.retries = len(properties.headers['x-death'])
+    log.debug("Received {}:{}".format(method.routing_key, event))
+    try:
+        handler(event)
+    except Retry as error:
+        if event.retries < max_retries:
+            # Publish manually to the delay exchange with a per-message TTL
+            log.info("Retry ({event.retries}) consuming event {event} in {delay:.1f}s".format(event=event, delay=error.delay))
+            channel.basic_ack(delivery_tag=method.delivery_tag)
+            properties.expiration = str(int(error.delay * 1000))
+            channel.basic_publish(exchange=delay_exchange,
+                                  routing_key=method.routing_key,
+                                  body=body,
+                                  properties=properties,
+                                  )
+        else:
+            # Reject puts the message into the dead-letter queue if there is one
+            log.warning("Exceeded max retries ({}) for event {}".format(max_retries, event))
+            channel.basic_reject(delivery_tag=method.delivery_tag, requeue=False)
+    except:
+        # Note: If we want immediate requeueing, add a `RequeueError` that
+        # a consumer can raise to trigger requeuing. Dead-letter queues are
+        # a better choice in most cases.
+        channel.basic_reject(delivery_tag=method.delivery_tag, requeue=False)
+        raise
+    else:
+        channel.basic_ack(delivery_tag=method.delivery_tag)
 
 
 class Transport(object):
@@ -51,6 +106,50 @@ class Transport(object):
         self.messages = []
         self.connection_settings = _connection_settings
         self.channel = None
+
+    def connect(self):
+        """
+        For now we use a synchronous connection - caller is blocked until a
+        message is added to the queue. We might switch to asynch connections
+        should this incur noticable latencies.
+        """
+        params = URLParameters(self.connection_settings)
+        self.connection = BlockingConnection(params)
+        self.channel = self.connection.channel()
+
+        # set up the Exchange (if it does not exist)
+        self.channel.exchange_declare(exchange=self.exchange,
+                                      type=self.exchange_type,
+                                      durable=True,
+                                      auto_delete=False,
+                                      )
+
+    def disconnect(self):
+        """
+        Disconnect from queue. The API is a little weird. First we close the
+        connection, then disconnect from the socket. The last step will remove
+        the connection from the RabbitMQ connection pool.
+
+        Make sure you don't close the channel, otherwise the connection cannot
+        be closed anymore.
+        """
+        self.connection.close()
+        self.channel = None
+        self.connection = None
+
+
+class Sender(Transport):
+
+    def __enter__(self):
+        if self.context_depth == 0:
+            self.connect()
+        self.context_depth += 1
+
+    def __exit__(self, exc_type, exc_value, exc_traceback):
+        self.context_depth -= 1
+        if self.context_depth == 0:
+            self.disconnect()
+        return False
 
     def push(self, data, routing_key=None):
         self.pending.append((data, routing_key))
@@ -100,74 +199,75 @@ class Transport(object):
                 properties=BasicProperties(delivery_mode=2),
                 )
 
-    def receive(self, callback, name, binding_keys=(), dead_letter=False,
-                durable=True, exclusive=False, auto_delete=False):
+
+class Receiver(Transport):
+
+    def __init__(self, *args, **kwargs):
+        super(Receiver, self).__init__(*args, **kwargs)
+        self.connect()
+
+    def bind_routing_keys(self, exchange, queue_name, binding_keys):
+        for binding_key in binding_keys:
+            self.channel.queue_bind(exchange=exchange,
+                                    routing_key=binding_key,
+                                    queue=queue_name)
+
+    def register(self, handler, name, binding_keys=(), dead_letter=False,
+                 durable=True, exclusive=False, auto_delete=False,
+                 max_retries=0):
+        retry_exchange = name + '-retry'
+        delay_exchange = name + '-delay'
+        dead_letter_exchange = name + '-dlx'
+
         arguments = {}
         if dead_letter:
-            dlx = name + '-dlx'
-            self.channel.exchange_declare(exchange=dlx, type=self.exchange_type)
+            self.channel.exchange_declare(exchange=dead_letter_exchange, type=self.exchange_type)
             result = self.channel.queue_declare(queue=name + '-dl', durable=True)
             queue_name = result.method.queue
-            for binding_key in binding_keys:
-                self.channel.queue_bind(exchange=dlx,
-                                        routing_key=binding_key,
-                                        queue=queue_name)
-            arguments["x-dead-letter-exchange"] = dlx
+            self.bind_routing_keys(dead_letter_exchange, queue_name, binding_keys)
+            arguments["x-dead-letter-exchange"] = dead_letter_exchange
+
+        # Create receiver queue and bind to the default exchange
         self.channel.queue_declare(queue=name,
                                    durable=durable,
                                    exclusive=exclusive,
                                    auto_delete=auto_delete,
                                    arguments=arguments,
                                    )
-        for binding_key in binding_keys:
-            self.channel.queue_bind(queue=name,
-                                    exchange=self.exchange,
-                                    routing_key=binding_key)
+        self.bind_routing_keys(self.exchange, name, binding_keys)
+
+        # Re-route failed messages to a retry dead letter queue
+        if max_retries > 0:
+            # Declare the exchange where messages expired in the wait queue are routed
+            self.channel.exchange_declare(exchange=retry_exchange, type=self.exchange_type)
+            self.channel.exchange_declare(exchange=delay_exchange, type=self.exchange_type)
+            retry_arguments = {'x-dead-letter-exchange': retry_exchange}
+            result = self.channel.queue_declare(queue=name + '-wait',
+                                                durable=durable,
+                                                arguments=retry_arguments)
+            queue_name = result.method.queue
+            self.bind_routing_keys(delay_exchange, queue_name, binding_keys)
+            # Bind the consumer queue to the retry exchange
+            self.bind_routing_keys(retry_exchange, name, binding_keys)
+
+        callback = partial(receive_callback, handler, delay_exchange, max_retries)
         self.channel.basic_consume(callback, queue=name)
-        # Note: If we want to run multiple receivers in one process, we should
-        # split basic_consume and start_consuming into different methods.
+
+    def stop_consuming(self):
+        self.channel.stop_consuming()
+        self.disconnect()
+
+    def start_consuming(self, timeout=None):
+        """
+        Enter IO consumer loop after calling `register`. If timeout is given,
+        the consumer will be stopped after the specified number of seconds.
+        """
+        if timeout:
+            self.connection.add_timeout(timeout, self.stop_consuming)
         try:
             self.channel.start_consuming()
         except KeyboardInterrupt:
-            self.channel.stop_consuming()
-            self.disconnect()
-
-    def __enter__(self):
-        if self.context_depth == 0:
-            self.connect()
-        self.context_depth += 1
-
-    def __exit__(self, exc_type, exc_value, exc_traceback):
-        self.context_depth -= 1
-        if self.context_depth == 0:
-            self.disconnect()
-        return False
-
-    def connect(self):
-        """
-        For now we use a synchronous connection - caller is blocked until a
-        message is added to the queue. We might switch to asynch connections
-        should this incur noticable latencies.
-        """
-        params = URLParameters(self.connection_settings)
-        self.connection = BlockingConnection(params)
-        self.channel = self.connection.channel()
-
-        # set up the Exchange (if it does not exist)
-        self.channel.exchange_declare(exchange=self.exchange,
-                                      type=self.exchange_type,
-                                      durable=True,
-                                      auto_delete=False,
-                                      )
-
-    def disconnect(self):
-        """
-        Disconnect from queue. The API is a little weird. First we close the
-        connection, then disconnect from the socket. The last step will remove
-        the connection from the RabbitMQ connection pool.
-
-        Make sure you don't close the channel, otherwise the connection cannot
-        be closed anymore.
-        """
-        self.connection.close()
-        self.connection = None
+            self.stop_consuming()
+        except:
+            self.stop_consuming()
+            raise

--- a/examples/dead_letter.py
+++ b/examples/dead_letter.py
@@ -2,7 +2,7 @@
 
 import sys
 
-from domain_events import receive_domain_events
+from domain_events import Receiver
 
 
 def handler(event):
@@ -11,4 +11,6 @@ def handler(event):
 
 if __name__ == '__main__':
     binding_keys = sys.argv[1:]
-    receive_domain_events(handler, name='stumbling-steve', binding_keys=binding_keys, dead_letter=True)
+    receiver = Receiver()
+    receiver.register(handler, name='stumbling-steve', binding_keys=binding_keys, dead_letter=True)
+    receiver.start_consuming()

--- a/examples/retry_after_delay.py
+++ b/examples/retry_after_delay.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import logging
+import sys
+
+from domain_events import Receiver, Retry
+
+
+logging.basicConfig(level=logging.INFO)
+
+
+def handler(event):
+    delay = 5.0 + (10.0 * event.retries)
+    raise Retry(delay)
+
+
+if __name__ == '__main__':
+    binding_keys = sys.argv[1:]
+    receiver = Receiver()
+    receiver.register(handler, name='retry-ronny', binding_keys=binding_keys, max_retries=3)
+    receiver.start_consuming()

--- a/examples/simple_receiver.py
+++ b/examples/simple_receiver.py
@@ -2,7 +2,7 @@
 
 import sys
 
-from domain_events import receive_domain_events
+from domain_events import Receiver
 
 
 def log_event(event):
@@ -11,4 +11,6 @@ def log_event(event):
 
 if __name__ == '__main__':
     binding_keys = sys.argv[1:]
-    receive_domain_events(log_event, name='simple-receiver', binding_keys=binding_keys)
+    receiver = Receiver()
+    receiver.register(log_event, name='simple-receiver', binding_keys=binding_keys)
+    receiver.start_consuming()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 -f http://galaxy/packages/
 --trusted-host galaxy
-pika>=0.9.13
+pika>=0.10.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [versioneer]
 VCS = git
-style = pep440
+style = git-describe
 versionfile_source = domain_events/_version.py
 versionfile_build = domain_events/_version.py
 tag_prefix =

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,6 @@ setup(
     author_email='webteam@ableton.com',
     license='MIT',
     packages=['domain_events'],
-    install_requires=["pika >= 0.9.13"],
+    install_requires=["pika >= 0.10.0"],
     zip_safe=False,
 )


### PR DESCRIPTION
- Split `Transport` in `Sender` and `Receiver` with common base class
- Allow registering multiple handlers in one receiver
